### PR TITLE
DX: One-command UI preview, auto-published manifest, and smoother Anvil/MetaMask flow

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,6 @@
 ### Token Host Builder
 
-Turns a Token Host Schema (THS) document into deterministic Solidity artifacts (and, later, a generated UI) that can be deployed and self-hosted.
+Turns a Token Host Schema (THS) document into deterministic Solidity artifacts and a generated UI bundle that can be deployed and self-hosted.
 
 - Canonical product spec: `SPEC.md`
 - Spec-to-code backlog: `AGENTS.md`
@@ -27,6 +27,12 @@ anvil
 
 # Deploy to local anvil (uses Anvil's default dev key unless ANVIL_PRIVATE_KEY is set)
 pnpm th deploy artifacts/job-board --chain anvil
+
+# Serve the generated UI locally (no Python required)
+pnpm th preview artifacts/job-board
+
+# Open http://127.0.0.1:3000/
+# MetaMask: approve switching/adding the Anvil network (chainId 31337).
 ```
 
 Environment examples:

--- a/packages/templates/next-export-ui/app/[collection]/ClientPage.tsx
+++ b/packages/templates/next-export-ui/app/[collection]/ClientPage.tsx
@@ -183,8 +183,17 @@ export default function CollectionListPage(props: { params: { collection: string
     return (
       <div className="card">
         <h2>Not deployed</h2>
-        <div className="muted">Run <span className="badge">th deploy</span> and re-publish the manifest for this UI.</div>
-        <div className="pre">manifest deploymentEntrypointAddress is 0x0</div>
+        <div className="muted">
+          This UI reads <span className="badge">/.well-known/tokenhost/manifest.json</span> at runtime, but the manifest still has a placeholder
+          deployment address (<span className="badge">deploymentEntrypointAddress = 0x0</span>).
+        </div>
+        <div className="muted" style={{ marginTop: 12 }}>
+          Run <span className="badge">th deploy {'<buildDir>'} --chain anvil</span>, then refresh this page.
+        </div>
+        <div className="muted" style={{ marginTop: 12 }}>
+          If you are hosting this UI remotely, publish the updated <span className="badge">manifest.json</span> to{' '}
+          <span className="badge">/.well-known/tokenhost/manifest.json</span>.
+        </div>
       </div>
     );
   }
@@ -231,4 +240,3 @@ export default function CollectionListPage(props: { params: { collection: string
     </>
   );
 }
-

--- a/packages/templates/next-export-ui/app/[collection]/delete/ClientPage.tsx
+++ b/packages/templates/next-export-ui/app/[collection]/delete/ClientPage.tsx
@@ -174,8 +174,17 @@ export default function DeleteRecordPage(props: { params: { collection: string }
     return (
       <div className="card">
         <h2>Not deployed</h2>
-        <div className="muted">Run <span className="badge">th deploy</span> and re-publish the manifest for this UI.</div>
-        <div className="pre">manifest deploymentEntrypointAddress is 0x0</div>
+        <div className="muted">
+          This UI reads <span className="badge">/.well-known/tokenhost/manifest.json</span> at runtime, but the manifest still has a placeholder
+          deployment address (<span className="badge">deploymentEntrypointAddress = 0x0</span>).
+        </div>
+        <div className="muted" style={{ marginTop: 12 }}>
+          Run <span className="badge">th deploy {'<buildDir>'} --chain anvil</span>, then refresh this page.
+        </div>
+        <div className="muted" style={{ marginTop: 12 }}>
+          If you are hosting this UI remotely, publish the updated <span className="badge">manifest.json</span> to{' '}
+          <span className="badge">/.well-known/tokenhost/manifest.json</span>.
+        </div>
       </div>
     );
   }
@@ -234,4 +243,3 @@ export default function DeleteRecordPage(props: { params: { collection: string }
     </div>
   );
 }
-

--- a/packages/templates/next-export-ui/app/[collection]/edit/ClientPage.tsx
+++ b/packages/templates/next-export-ui/app/[collection]/edit/ClientPage.tsx
@@ -215,8 +215,17 @@ export default function EditRecordPage(props: { params: { collection: string } }
     return (
       <div className="card">
         <h2>Not deployed</h2>
-        <div className="muted">Run <span className="badge">th deploy</span> and re-publish the manifest for this UI.</div>
-        <div className="pre">manifest deploymentEntrypointAddress is 0x0</div>
+        <div className="muted">
+          This UI reads <span className="badge">/.well-known/tokenhost/manifest.json</span> at runtime, but the manifest still has a placeholder
+          deployment address (<span className="badge">deploymentEntrypointAddress = 0x0</span>).
+        </div>
+        <div className="muted" style={{ marginTop: 12 }}>
+          Run <span className="badge">th deploy {'<buildDir>'} --chain anvil</span>, then refresh this page.
+        </div>
+        <div className="muted" style={{ marginTop: 12 }}>
+          If you are hosting this UI remotely, publish the updated <span className="badge">manifest.json</span> to{' '}
+          <span className="badge">/.well-known/tokenhost/manifest.json</span>.
+        </div>
       </div>
     );
   }
@@ -300,4 +309,3 @@ export default function EditRecordPage(props: { params: { collection: string } }
     </div>
   );
 }
-

--- a/packages/templates/next-export-ui/app/[collection]/new/ClientPage.tsx
+++ b/packages/templates/next-export-ui/app/[collection]/new/ClientPage.tsx
@@ -80,8 +80,17 @@ export default function CreateRecordPage(props: { params: { collection: string }
     return (
       <div className="card">
         <h2>Not deployed</h2>
-        <div className="muted">Run <span className="badge">th deploy</span> and re-publish the manifest for this UI.</div>
-        <div className="pre">manifest deploymentEntrypointAddress is 0x0</div>
+        <div className="muted">
+          This UI reads <span className="badge">/.well-known/tokenhost/manifest.json</span> at runtime, but the manifest still has a placeholder
+          deployment address (<span className="badge">deploymentEntrypointAddress = 0x0</span>).
+        </div>
+        <div className="muted" style={{ marginTop: 12 }}>
+          Run <span className="badge">th deploy {'<buildDir>'} --chain anvil</span>, then refresh this page.
+        </div>
+        <div className="muted" style={{ marginTop: 12 }}>
+          If you are hosting this UI remotely, publish the updated <span className="badge">manifest.json</span> to{' '}
+          <span className="badge">/.well-known/tokenhost/manifest.json</span>.
+        </div>
       </div>
     );
   }
@@ -206,4 +215,3 @@ export default function CreateRecordPage(props: { params: { collection: string }
     </div>
   );
 }
-

--- a/packages/templates/next-export-ui/app/[collection]/view/ClientPage.tsx
+++ b/packages/templates/next-export-ui/app/[collection]/view/ClientPage.tsx
@@ -207,8 +207,17 @@ export default function ViewRecordPage(props: { params: { collection: string } }
     return (
       <div className="card">
         <h2>Not deployed</h2>
-        <div className="muted">Run <span className="badge">th deploy</span> and re-publish the manifest for this UI.</div>
-        <div className="pre">manifest deploymentEntrypointAddress is 0x0</div>
+        <div className="muted">
+          This UI reads <span className="badge">/.well-known/tokenhost/manifest.json</span> at runtime, but the manifest still has a placeholder
+          deployment address (<span className="badge">deploymentEntrypointAddress = 0x0</span>).
+        </div>
+        <div className="muted" style={{ marginTop: 12 }}>
+          Run <span className="badge">th deploy {'<buildDir>'} --chain anvil</span>, then refresh this page.
+        </div>
+        <div className="muted" style={{ marginTop: 12 }}>
+          If you are hosting this UI remotely, publish the updated <span className="badge">manifest.json</span> to{' '}
+          <span className="badge">/.well-known/tokenhost/manifest.json</span>.
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
## Problem
The Quickstart path built and deployed contracts, but it was unclear how to actually *load the website*.

Users ended up reaching for an ad-hoc static server (often Python), and even after `th deploy` the UI could still show `deploymentEntrypointAddress = 0x0` because the served manifest copy inside `ui-site/` was not being updated.

## What changed
- **New `th preview` command** to serve the generated static UI locally (no Python required).
  - Serves `<buildDir>/ui-site` with trailing-slash handling (Next export) and `Cache-Control: no-store` so manifest updates show up immediately.
  - Prints the local URL plus manifest/deployment status and the exact next step if the app is not deployed yet.
- **Manifest auto-publishing**
  - `th deploy` and `th verify` now re-publish the updated `manifest.json` into the served UI locations:
    - `ui-site/.well-known/tokenhost/manifest.json`
    - `ui-site/manifest.json`
  - This eliminates the “deploy succeeded but UI still shows 0x0” foot-gun for local workflows.
- **Clearer CLI guidance**
  - `th build` now prints concrete next steps (deploy + preview).
  - `th init` project README now includes `th preview`.
- **Better runtime UX**
  - UI “Not deployed” message is explicit about what is missing and where the manifest is read from.
  - MetaMask/Anvil flow improved: when switching to chainId 31337 fails because the chain isn't configured (MetaMask 4902), the UI attempts `wallet_addEthereumChain` then retries.
- **Docs**
  - Root Quickstart includes `th preview` and a short MetaMask chain note.

## How to test
1) `pnpm install`
2) `pnpm th build apps/example/job-board.schema.json --out artifacts/job-board`
3) In another terminal: `anvil`
4) `pnpm th deploy artifacts/job-board --chain anvil`
5) `pnpm th preview artifacts/job-board` and open http://127.0.0.1:3000/

## Notes
- This is additive and backwards-compatible. The UI remains a static export; `th preview` is a tiny Node static server intended for local DX.
