### PR TITLE
CLI DX: add th dev (interactive + non-interactive end-to-end workflow)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -12,24 +12,14 @@ Turns a Token Host Schema (THS) document into deterministic Solidity artifacts a
 
 ## Quickstart (New Pipeline)
 
-Prereqs: Node >= 20, pnpm (repo uses `packageManager`), Foundry optional unless deploying.
+Prereqs: Node >= 20, pnpm (repo uses `packageManager`), Foundry required for local anvil (`th dev` default) and for `th verify`.
 
 ```bash
 pnpm install
 pnpm th doctor
 
-# Validate + build artifacts (Solidity + compile + manifest)
-pnpm th validate apps/example/job-board.schema.json
-pnpm th build apps/example/job-board.schema.json --out artifacts/job-board
-
-# In another terminal:
-anvil
-
-# Deploy to local anvil (uses Anvil's default dev key unless ANVIL_PRIVATE_KEY is set)
-pnpm th deploy artifacts/job-board --chain anvil
-
-# Serve the generated UI locally (no Python required)
-pnpm th preview artifacts/job-board
+# One command: validate + build + start anvil + deploy + serve UI
+pnpm th dev apps/example/job-board.schema.json
 
 # Open http://127.0.0.1:3000/
 # MetaMask: approve switching/adding the Anvil network (chainId 31337).

--- a/test/testCliDev.js
+++ b/test/testCliDev.js
@@ -1,0 +1,57 @@
+import { expect } from 'chai';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { spawnSync } from 'child_process';
+
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(value, null, 2));
+}
+
+function runTh(args, cwd) {
+  return spawnSync('node', [path.resolve('packages/cli/dist/index.js'), ...args], {
+    cwd,
+    encoding: 'utf-8'
+  });
+}
+
+function minimalSchema(overrides = {}) {
+  return {
+    thsVersion: '2025-12',
+    schemaVersion: '0.0.1',
+    app: {
+      name: 'Dev Command Test',
+      slug: 'dev-command-test',
+      features: { uploads: false, onChainIndexing: true }
+    },
+    collections: [
+      {
+        name: 'Item',
+        fields: [{ name: 'title', type: 'string', required: true }],
+        createRules: { required: ['title'], access: 'public' },
+        visibilityRules: { gets: ['title'], access: 'public' },
+        updateRules: { mutable: ['title'], access: 'owner' },
+        deleteRules: { softDelete: true, access: 'owner' },
+        indexes: { unique: [], index: [] }
+      }
+    ],
+    ...overrides
+  };
+}
+
+describe('th dev', function () {
+  it('supports --dry-run (no side effects)', function () {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'th-dev-'));
+    const schemaPath = path.join(dir, 'schema.json');
+    writeJson(schemaPath, minimalSchema());
+
+    const res = runTh(['dev', schemaPath, '--dry-run'], process.cwd());
+    expect(res.status, res.stderr || res.stdout).to.equal(0);
+    expect(res.stdout).to.include('Plan:');
+    expect(res.stdout).to.include('- build:');
+    expect(res.stdout).to.include('- deploy:');
+    expect(res.stdout).to.include('- preview:');
+  });
+});
+


### PR DESCRIPTION
## Why
Users can successfully follow the new-pipeline Quickstart but still get stuck on the multi-step flow (validate → build → start anvil → deploy → preview). The UX also makes it easy to end up with an app that looks “Not deployed” even after deploying.

## What this PR does
- Adds **`th dev`**: a single command that orchestrates the full local workflow:
  - validate + lint schema
  - build artifacts + static export UI
  - **optionally start Anvil** (if targeting `--chain anvil`)
  - deploy and re-publish the manifest into `ui-site/`
  - serve the UI locally (no Python)
- Supports **both interactive and non-interactive** operation:
  - If run in a TTY with no schema arg, it can prompt/select a schema.
  - All options are available as flags for scripting.
  - Includes `--dry-run` for safe inspection.
- Refactors preview/deploy/build internals into reusable helpers so `th dev` can reuse the same logic.
- Updates root `Readme.md` Quickstart to the new one-command flow.
- Adds a smoke test for `th dev --dry-run`.

## Usage
Local dev (default):
```bash
pnpm th dev apps/example/job-board.schema.json
```

Non-interactive scripting example:
```bash
th dev ./my.schema.json --chain anvil --out ./artifacts/my-app --host 127.0.0.1 --port 3000
```

Dry-run:
```bash
th dev apps/example/job-board.schema.json --dry-run
```

## Notes
- `th dev` defaults output to `artifacts/<appSlug>` when `--out` is not provided.
- If `th dev` starts Anvil, it manages that process lifecycle while the preview server is running.
