### PR TITLE
DX: local Anvil faucet endpoint + UI button

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -23,6 +23,7 @@ pnpm th dev apps/example/job-board.schema.json
 
 # Open http://127.0.0.1:3000/
 # MetaMask: approve switching/adding the Anvil network (chainId 31337).
+# Use the "Get test ETH" button (local faucet) if your wallet needs funds.
 ```
 
 Environment examples:

--- a/packages/templates/next-export-ui/app/layout.tsx
+++ b/packages/templates/next-export-ui/app/layout.tsx
@@ -3,6 +3,7 @@ import './globals.css';
 import React from 'react';
 
 import ConnectButton from '../src/components/ConnectButton';
+import FaucetButton from '../src/components/FaucetButton';
 import { ths } from '../src/lib/ths';
 
 export const metadata = {
@@ -20,7 +21,10 @@ export default function RootLayout(props: { children: React.ReactNode }) {
               <h1>{ths.app.name}</h1>
               <span className="badge">{ths.schemaVersion}</span>
             </div>
-            <ConnectButton />
+            <div style={{ display: 'flex', gap: 10, alignItems: 'center' }}>
+              <FaucetButton />
+              <ConnectButton />
+            </div>
           </div>
           {props.children}
         </div>

--- a/packages/templates/next-export-ui/src/components/FaucetButton.tsx
+++ b/packages/templates/next-export-ui/src/components/FaucetButton.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+
+import { fetchManifest, getPrimaryDeployment } from '../lib/manifest';
+import { chainFromId } from '../lib/chains';
+import { requestWalletAddress } from '../lib/clients';
+
+type FaucetStatus = {
+  ok: boolean;
+  enabled: boolean;
+  chainId: number | null;
+  targetEthDefault?: number;
+  reason?: string | null;
+};
+
+async function tryFetchFaucetStatus(): Promise<FaucetStatus | null> {
+  try {
+    const res = await fetch('/__tokenhost/faucet', { cache: 'no-store' });
+    if (!res.ok) return null;
+    const json = (await res.json()) as FaucetStatus;
+    if (!json || typeof json !== 'object') return null;
+    return json;
+  } catch {
+    return null;
+  }
+}
+
+export default function FaucetButton() {
+  const [enabled, setEnabled] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [note, setNote] = useState<string | null>(null);
+  const targetEthRef = useRef<number>(10);
+  const noteTimerRef = useRef<number | null>(null);
+
+  const hasWallet = useMemo(() => typeof (globalThis as any).ethereum !== 'undefined', []);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      if (!hasWallet) return;
+      try {
+        const manifest = await fetchManifest();
+        const deployment = getPrimaryDeployment(manifest);
+        const chainId = Number(deployment?.chainId ?? NaN);
+        if (!Number.isFinite(chainId) || chainId !== 31337) return;
+
+        const status = await tryFetchFaucetStatus();
+        if (!status?.ok || !status.enabled) return;
+
+        const targetEth = Number(status.targetEthDefault ?? 10);
+        if (Number.isFinite(targetEth) && targetEth > 0) {
+          targetEthRef.current = targetEth;
+        }
+
+        if (!cancelled) setEnabled(true);
+      } catch {
+        // ignore
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [hasWallet]);
+
+  function setTimedNote(message: string) {
+    setNote(message);
+    if (noteTimerRef.current !== null) {
+      window.clearTimeout(noteTimerRef.current);
+      noteTimerRef.current = null;
+    }
+    noteTimerRef.current = window.setTimeout(() => setNote(null), 8000);
+  }
+
+  useEffect(() => {
+    return () => {
+      if (noteTimerRef.current !== null) window.clearTimeout(noteTimerRef.current);
+    };
+  }, []);
+
+  async function requestFaucet() {
+    if (!enabled || busy) return;
+    setBusy(true);
+    setNote(null);
+
+    try {
+      const manifest = await fetchManifest();
+      const deployment = getPrimaryDeployment(manifest);
+      const chainId = Number(deployment?.chainId ?? NaN);
+      if (!Number.isFinite(chainId)) throw new Error('Missing chainId in manifest deployment.');
+
+      const chain = chainFromId(chainId);
+      const address = await requestWalletAddress(chain);
+
+      const res = await fetch('/__tokenhost/faucet', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ address })
+      });
+      const json = (await res.json().catch(() => null)) as any;
+      if (!res.ok || !json?.ok) {
+        const msg = String(json?.error ?? `Faucet failed (HTTP ${res.status}).`);
+        throw new Error(msg);
+      }
+
+      setTimedNote(`Funded to ~${targetEthRef.current} ETH`);
+    } catch (e: any) {
+      setTimedNote(String(e?.message ?? e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (!enabled) return null;
+
+  return (
+    <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+      <button className="btn" onClick={() => void requestFaucet()} disabled={busy} title="Local faucet (anvil)">
+        {busy ? 'Funding…' : 'Get test ETH'}
+      </button>
+      {note ? (
+        <span className="badge" title={note} style={{ maxWidth: 240, overflow: 'hidden', textOverflow: 'ellipsis' }}>
+          {note}
+        </span>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
Adds a dev-only faucet flow to remove the "I have no ETH" footgun during local Anvil development.

What changed
- CLI preview server serves GET/HEAD/POST /__tokenhost/faucet (only enabled for Anvil / chainId 31337).
  - Idempotent top-up: if the requested address is below the target balance, it uses anvil_setBalance to bring it up (default ~10 ETH).
  - Status endpoint returns { enabled, chainId, targetEthDefault } so the UI can self-hide when unavailable.
- th dev and th preview wire faucet config automatically on Anvil (disable via --no-faucet).
- Generated Next.js export UI adds a "Get test ETH" button in the navbar when the faucet endpoint is enabled.
- Quickstart docs mention the button.

Why
- Gas=0 is not a practical path with MetaMask.
- A local faucet is the simplest DX to get users unstuck quickly.

Notes / safety
- Faucet is only enabled when serving an Anvil build; otherwise the UI button is hidden and POST returns disabled.
- Default bind is 127.0.0.1; avoid exposing the preview server publicly.

Testing
- pnpm test
