### PR TITLE
CLI DX: promote th up/th run as one-command local orchestration

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -12,14 +12,14 @@ Turns a Token Host Schema (THS) document into deterministic Solidity artifacts a
 
 ## Quickstart (New Pipeline)
 
-Prereqs: Node >= 20, pnpm (repo uses `packageManager`), Foundry required for local anvil (`th dev` default) and for `th verify`.
+Prereqs: Node >= 20, pnpm (repo uses `packageManager`), Foundry required for local anvil (`th up` default) and for `th verify`.
 
 ```bash
 pnpm install
 pnpm th doctor
 
-# One command: validate + build + start anvil + deploy + serve UI
-pnpm th dev apps/example/job-board.schema.json
+# One command: validate + build + start anvil + deploy + serve UI + local faucet
+pnpm th up apps/example/job-board.schema.json
 
 # Open http://127.0.0.1:3000/
 # MetaMask: approve switching/adding the Anvil network (chainId 31337).

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1074,7 +1074,7 @@ function buildFromSchema(
     console.log('');
     console.log('Next steps:');
     if (opts.schemaPathForHints) {
-      console.log(`  th dev ${opts.schemaPathForHints}            # build+deploy+preview (local)`);
+      console.log(`  th up ${opts.schemaPathForHints}             # build+deploy+preview (local)`);
     }
     console.log(`  th deploy ${resolvedOutDir} --chain anvil   # start anvil first`);
     console.log(`  th deploy ${resolvedOutDir} --chain sepolia # requires RPC + funded key`);
@@ -1302,7 +1302,7 @@ program
         '',
         '```bash',
         `pnpm th doctor`,
-        `pnpm th dev ${schemaPath}`,
+        `pnpm th up ${schemaPath}`,
         '```',
         ''
       ].join('\n')
@@ -1473,9 +1473,11 @@ function anyPaidCreates(schema: ThsSchema): boolean {
 }
 
 program
-  .command('dev')
+  .command('up')
+  .alias('run')
+  .alias('dev')
   .argument('[schema]', 'Path to THS schema JSON file (defaults to an example schema when available)')
-  .description('All-in-one local dev: validate + build + (start anvil) + deploy + preview')
+  .description('All-in-one local flow: validate + build + (start anvil) + deploy + preview + faucet')
   .option('--out <dir>', 'Build output directory (defaults to artifacts/<appSlug>)')
   .option('--chain <name>', 'Chain name (anvil|sepolia)', 'anvil')
   .option('--rpc <url>', 'RPC URL override')
@@ -1562,7 +1564,7 @@ program
             } else {
               if (!interactive) {
                 console.error('No schema provided and none found under apps/.');
-                console.error('Run: th dev <path/to/schema.schema.json>');
+                console.error('Run: th up <path/to/schema.schema.json>');
                 process.exitCode = 1;
                 return;
               }

--- a/test/testCliDev.js
+++ b/test/testCliDev.js
@@ -40,8 +40,31 @@ function minimalSchema(overrides = {}) {
   };
 }
 
-describe('th dev', function () {
-  it('supports --dry-run (no side effects)', function () {
+describe('th up/run/dev', function () {
+  it('supports --dry-run (no side effects) via th up', function () {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'th-dev-'));
+    const schemaPath = path.join(dir, 'schema.json');
+    writeJson(schemaPath, minimalSchema());
+
+    const res = runTh(['up', schemaPath, '--dry-run'], process.cwd());
+    expect(res.status, res.stderr || res.stdout).to.equal(0);
+    expect(res.stdout).to.include('Plan:');
+    expect(res.stdout).to.include('- build:');
+    expect(res.stdout).to.include('- deploy:');
+    expect(res.stdout).to.include('- preview:');
+  });
+
+  it('supports --dry-run via th run alias', function () {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'th-run-'));
+    const schemaPath = path.join(dir, 'schema.json');
+    writeJson(schemaPath, minimalSchema());
+
+    const res = runTh(['run', schemaPath, '--dry-run'], process.cwd());
+    expect(res.status, res.stderr || res.stdout).to.equal(0);
+    expect(res.stdout).to.include('Plan:');
+  });
+
+  it('keeps th dev alias working', function () {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'th-dev-'));
     const schemaPath = path.join(dir, 'schema.json');
     writeJson(schemaPath, minimalSchema());
@@ -49,9 +72,5 @@ describe('th dev', function () {
     const res = runTh(['dev', schemaPath, '--dry-run'], process.cwd());
     expect(res.status, res.stderr || res.stdout).to.equal(0);
     expect(res.stdout).to.include('Plan:');
-    expect(res.stdout).to.include('- build:');
-    expect(res.stdout).to.include('- deploy:');
-    expect(res.stdout).to.include('- preview:');
   });
 });
-


### PR DESCRIPTION
Promotes a single orchestration command for local development while preserving backwards compatibility.

What changed
- Added `th up` as the primary all-in-one command for local flow.
- Added `th run` alias for the same orchestration command.
- Kept `th dev` as a compatibility alias.
- Updated command description to explicitly include faucet in the flow.
- Updated generated quickstart hint from `th dev` to `th up`.
- Updated root README quickstart from `pnpm th dev ...` to `pnpm th up ...`.
- Expanded CLI tests to validate dry-run behavior for `th up`, `th run`, and `th dev` aliases.

Why
- Makes the CLI intent clearer: one command orchestrates build, deploy, preview, and faucet by default.
- Keeps existing scripts/docs from breaking while migrating users to the cleaner command surface.

Validation
- `pnpm test` (29 passing)
