### PR TITLE
Generate: add --with-tests test scaffold emission

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -40,6 +40,11 @@ pnpm legacy:build-run
 
 ## Testing
 
+Token Host Builder uses a two-layer quality model:
+
+- Builder framework tests: validate schema/generator/CLI/runtime behavior.
+- Generated app tests: validate that produced apps behave correctly for their schema (canonical `job-board` is enforced in CI today).
+
 Fast local suite (no local chain required):
 
 ```bash
@@ -52,6 +57,27 @@ Local integration suite (requires `anvil` on PATH):
 ```bash
 pnpm test:integration
 ```
+
+Generated app test scaffold (issue #28 slice):
+
+```bash
+pnpm th generate apps/example/job-board.schema.json --out artifacts/job-board --with-tests
+cd artifacts/job-board/ui
+pnpm test
+```
+
+Current integration coverage includes:
+
+- preview auto-deploy behavior and manifest publication checks,
+- local faucet behavior checks,
+- canonical `apps/example/job-board.schema.json` end-to-end assertions:
+  - Candidate CRUD flows,
+  - JobPosting paid-create enforcement,
+  - generated UI route health checks.
+
+Planned expansion:
+
+- generated apps emitted by `th generate` should include app-level test scaffolds/scripts so downstream repos can run schema-specific tests by default.
 
 ## CI
 

--- a/packages/templates/next-export-ui/test-scaffold/tests/README.md
+++ b/packages/templates/next-export-ui/test-scaffold/tests/README.md
@@ -1,0 +1,8 @@
+Generated app test scaffold
+
+This directory is emitted by `th generate --with-tests`.
+
+- `contract/smoke.mjs` validates baseline generated app contract test preconditions.
+- `ui/smoke.mjs` validates baseline generated UI route/component preconditions.
+
+These are starter tests and are intended to be expanded with schema-specific assertions.

--- a/packages/templates/next-export-ui/test-scaffold/tests/contract/smoke.mjs
+++ b/packages/templates/next-export-ui/test-scaffold/tests/contract/smoke.mjs
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+
+function mustExist(root, relPath) {
+  const p = path.join(root, relPath);
+  assert.equal(fs.existsSync(p), true, `Missing required generated file: ${relPath}`);
+  return p;
+}
+
+const root = process.cwd();
+const thsPath = mustExist(root, 'src/generated/ths.ts');
+mustExist(root, 'src/lib/app.ts');
+mustExist(root, 'src/lib/abi.ts');
+
+const thsSource = fs.readFileSync(thsPath, 'utf-8');
+assert.match(thsSource, /export const ths = /, 'Generated THS export is missing.');
+
+console.log('PASS contract smoke scaffold');

--- a/packages/templates/next-export-ui/test-scaffold/tests/ui/smoke.mjs
+++ b/packages/templates/next-export-ui/test-scaffold/tests/ui/smoke.mjs
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+
+function mustExist(root, relPath) {
+  const p = path.join(root, relPath);
+  assert.equal(fs.existsSync(p), true, `Missing required generated UI file: ${relPath}`);
+}
+
+const root = process.cwd();
+
+for (const relPath of [
+  'app/layout.tsx',
+  'app/page.tsx',
+  'app/[collection]/layout.tsx',
+  'app/[collection]/page.tsx',
+  'app/[collection]/new/page.tsx'
+]) {
+  mustExist(root, relPath);
+}
+
+console.log('PASS ui smoke scaffold');


### PR DESCRIPTION
Resolves #28.

Scope implemented in this slice
- Adds `th generate --with-tests` to emit a deterministic generated-app test scaffold.
- Emits scaffold files under generated `ui/tests/`:
  - `tests/contract/smoke.mjs`
  - `tests/ui/smoke.mjs`
  - `tests/README.md`
- Injects generated app package scripts when scaffold is requested:
  - `test`
  - `test:contract`
  - `test:ui`
- Keeps default behavior unchanged (no scaffold unless `--with-tests` is set).

Validation
- `pnpm test`
- `pnpm typecheck`
- Added generator test coverage for `--with-tests` behavior.
