### PR TITLE
Fix generated UI ABI getter calls for viem overload handling

### DIFF
--- a/packages/templates/next-export-ui/src/lib/app.ts
+++ b/packages/templates/next-export-ui/src/lib/app.ts
@@ -15,9 +15,8 @@ export function fnListIds(collectionName: string): string {
 }
 
 export function fnGet(collectionName: string): string {
-  // The generated contract overloads getC(uint256,bool) and getC(uint256).
-  // Use the full signature to disambiguate for viem encoding/decoding.
-  return `get${collectionName}(uint256)`;
+  // viem expects the function name (not full signature) and resolves overloads from args.
+  return `get${collectionName}`;
 }
 
 export function fnCreate(collectionName: string): string {

--- a/packages/templates/next-export-ui/test-scaffold/tests/ui/smoke.mjs
+++ b/packages/templates/next-export-ui/test-scaffold/tests/ui/smoke.mjs
@@ -26,6 +26,11 @@ async function assertRoute200(baseUrl, route) {
   const u = `${baseUrl}${route}`;
   const out = await fetchOrThrow(u);
   assert.equal(out.status, 200, `Expected ${u} to return 200, got ${out.status}`);
+  assert.equal(
+    out.text.includes('not found on ABI'),
+    false,
+    `Route ${u} rendered an ABI lookup error. Check generated UI function names vs ABI overload handling.`
+  );
 }
 
 async function runLiveChecks(root, baseUrl, ths) {


### PR DESCRIPTION
Summary:\n- fix generated UI runtime to pass function names (not full signatures) into viem for overloaded getter calls\n- retain ABI mismatch guardrails while avoiding viem encodeFunctionData failure\n- harden generated UI smoke checks to fail when route HTML contains "not found on ABI"\n\nValidation:\n- pnpm build\n- pnpm mocha test/integration/testGeneratedAppUiTests.js\n\nThis addresses runtime errors like: Function "getCandidate(uint256)" not found on ABI.